### PR TITLE
Migrate from `pykalman` to `pykalman-bardo`

### DIFF
--- a/dockerfile_airflow/requirements.txt
+++ b/dockerfile_airflow/requirements.txt
@@ -61,7 +61,7 @@ pyyamL
 lxml
 cssselect
 xverse
-pykalman
+pykalman-bardo
 vectorbt
 kaleido
 dataframe_image


### PR DESCRIPTION
Consider migration from `pykalman` to `pykalman-bardo`, as [pykalman](https://github.com/pykalman/pykalman) project is no longer maintained. There were some issues that were fixed, see: https://github.com/pybardo/pykalman/blob/v0.9.7/CHANGELOG

I'm going to maintain [pykalman-bardo](https://github.com/pybardo/pykalman), react to issues, and fix bugs. For now the API is the same as in the initial package, but it might evolve in time.

I hope you will find it useful for your project!